### PR TITLE
Alter Conflicting Alias  "fc"

### DIFF
--- a/etc/skel/.bashrc-latest
+++ b/etc/skel/.bashrc-latest
@@ -79,7 +79,7 @@ alias update-grub="sudo grub-mkconfig -o /boot/grub/grub.cfg"
 alias fixpng="find . -type f -name "*.png" -exec convert {} -strip {} \;"
 
 #add new fonts
-alias fc='sudo fc-cache -fv'
+alias newfonts='sudo fc-cache -fv'
 
 #copy/paste all content of /etc/skel over to home folder - Beware
 alias skel='cp -rf /etc/skel/* ~'


### PR DESCRIPTION
"fc" is a builtin shell command - https://www.systutorials.com/docs/linux/man/1p-fc/
The current "fc" alias does something completely different to what some scripts expect when invoking fc.
This is problematic and should be adjusted.