### PR TITLE
Update .bashrc-latest

### DIFF
--- a/etc/skel/.bashrc-latest
+++ b/etc/skel/.bashrc-latest
@@ -14,6 +14,11 @@
 
 export HISTCONTROL=ignoreboth:erasedups
 
+# Make nano the default editor
+
+export EDITOR='nano'
+export VISUAL='nano'
+
 PS1='[\u@\h \W]\$ '
 
 if [ -d "$HOME/.bin" ] ;
@@ -171,17 +176,17 @@ alias jctl="journalctl -p 3 -xb"
 
 #nano for important configuration files
 #know what you do in these files
-alias nlightdm="sudo nano /etc/lightdm/lightdm.conf"
-alias npacman="sudo nano /etc/pacman.conf"
-alias ngrub="sudo nano /etc/default/grub"
-alias nconfgrub="sudo nano /boot/grub/grub.cfg"
-alias nmkinitcpio="sudo nano /etc/mkinitcpio.conf"
-alias nmirrorlist="sudo nano /etc/pacman.d/mirrorlist"
-alias nsddm="sudo nano /etc/sddm.conf"
+alias nlightdm="sudo $EDITOR /etc/lightdm/lightdm.conf"
+alias npacman="sudo $EDITOR /etc/pacman.conf"
+alias ngrub="sudo $EDITOR /etc/default/grub"
+alias nconfgrub="sudo $EDITOR /boot/grub/grub.cfg"
+alias nmkinitcpio="sudo $EDITOR /etc/mkinitcpio.conf"
+alias nmirrorlist="sudo $EDITOR /etc/pacman.d/mirrorlist"
+alias nsddm="sudo $EDITOR /etc/sddm.conf"
 alias bls="betterlockscreen -u /usr/share/backgrounds/arcolinux/"
-alias nfstab="sudo nano /etc/fstab"
-alias nnsswitch="sudo nano /etc/nsswitch.conf"
-alias nsamba="sudo nano /etc/samba/smb.conf"
+alias nfstab="sudo $EDITOR /etc/fstab"
+alias nnsswitch="sudo $EDITOR /etc/nsswitch.conf"
+alias nsamba="sudo $EDITOR /etc/samba/smb.conf"
 
 #gpg
 #verify signature for isos


### PR DESCRIPTION
Hi Erik,
The idea of this pull request is to make it easier to the users to make customizations directly on bashrc-personal that will last.

Exported the variables EDITOR and VISUAL to use "nano" as the default editor, and updated aliases that called for "nano" to call for $EDITOR. This way, customization of EDITOR and VISUAL on .bashrc-personal will apply to all aliases, without the need of further creation of aliases.