### PR TITLE
Alias Fixes and Safety Checks to Destructive Commands

### DIFF
--- a/etc/skel/.bashrc-latest
+++ b/etc/skel/.bashrc-latest
@@ -103,8 +103,6 @@ alias update-grub="sudo grub-mkconfig -o /boot/grub/grub.cfg"
 #add new fonts
 alias update-fc='sudo fc-cache -fv'
 
-#copy/paste all content of /etc/skel over to home folder - backup of config created - beware
-alias skel="[ -d ~/.config ] || confirm 'Do you really want to update arcolinux application configurations? (Y/n)' && mkdir ~/.config && cp -Rf ~/.config ~/.config-backup-$(date +%Y.%m.%d-%H.%M.%S) && cp -rf /etc/skel/* ~"
 #backup contents of /etc/skel to hidden backup folder in home/user
 alias bupskel='cp -Rf /etc/skel ~/.skel-backup-$(date +%Y.%m.%d-%H.%M.%S)'
 
@@ -158,8 +156,8 @@ alias rams='rate-mirrors --allow-root --protocol https arch  | sudo tee /etc/pac
 alias vbm="confirm 'mount vbox share? (Y/n)' && sudo /usr/local/bin/arcolinux-vbox-share"
 
 #enabling vmware services
-alias start-vmware="sudo systemctl enable --now vmtoolsd.service"
-alias sv="sudo systemctl enable --now vmtoolsd.service"
+alias enable-vmwaretools="confirm 'Do you want to automatically start VMware Tools? (Y/n)' && sudo systemctl enable --now vmtoolsd.service"
+alias disable-vmwaretools="confirm 'Do you want to remove VMware Tools from autostart? (Y/n)' && sudo systemctl disable --now vmtoolsd.service"
 
 #shopt
 shopt -s autocd # change to named directory
@@ -316,7 +314,8 @@ alias personal='cp -Rf /personal/* ~'
 
 # Bash Scripts Section
 # # Confirmation Script accepting a query argument
-confirm() {
+confirm() 
+{
     # call with a prompt string or use a default ie confirm "prompt" && action here
     read -r -p "${1:-Are you sure? [y/N]} " response
     case "$response" in
@@ -354,6 +353,22 @@ ex ()
     esac
   else
     echo "'$1' is not a valid file"
+  fi
+}
+
+# # Skel is now a bash script
+# # copy/paste all content of /etc/skel over to home folder - backup of config created - beware
+skel() 
+{
+  timestamp=$(date +%Y.%m.%d-%H.%M.%S)
+  if [ ! -d ~/.config ]; then
+    mkdir ~/.config
+  fi
+  if confirm 'Do you really want to update arcolinux application configurations? (Y/n) '; then
+    cp -Rf ~/.config ~/.config-backup-$timestamp
+    echo "Backup of ~/.config created at ~/.config-backup-$timestamp"
+    cp -rf /etc/skel/* ~
+    echo "Successfully updated configurations from /etc/skel"
   fi
 }
 


### PR DESCRIPTION
Below is the list of alterations with the reasoning as to why they were made:

- Change: Change default pager back to less with ANSI character support (-R flag) to enable color
  - Reason: Most is still poorly documented and notably lacks logging features when compared to less
- Change: Define an alias aurhelper pointing to paru
  - Reason: Use this alias to update the other AUR helper alias's instead of bloating with alias's. Arcolinux seems to have chosen paru as the default so i've set it to paru and ammended the helper alias's to use paru via this alias. 
  - A user can now create a single alias for aurhelper in their .bashrc_personal to override it to something like yay and take advantage of the existing default alias's. Simplifies alias management.
- Change: Creation of "confirm" bash script
  - Reason: bashrc contains some destructive alias's that are not safety checked (cb, cf, cz, skel, ssn, ssr, rmgitcache etc) this bash script adds a basic confirmation prompt when they're invoked to safeguard the user from typos turning their computer off, blowing away their app config before they run bupskel etc etc
  - It is also a really nice script to have on hand for the users own alias's and basic bash functions.
- Change: Rename all the editor commands from the n prefix to an e prefix
  - Reason: An N prefix, ex ngrub, assumes the user will keep using nano as it stands for nano grub. This change alters the mnemonic to _**e**dit_ _file_ from _nano_ _file_ which makes it editor agnostic.
  - Additionally fixed some hardcodes for nano in that list to use the $EDITOR envvar.
- Change: Rename downgrada to downgradearco 
  - Reason: a and e are visually similar in some terminal fonts and some autocorrect tools (eg thefuck) will suggest downgrada over downgrade due to it been alphabetically first. This is likely undesired.
-  Change: probe alias altered to NOT upload data by default
    - Reason: Resulting data can be reviewed offline, user may not want to upload the diag data to a thirdparty site for privacy reasons.
    - Additionally created alias probeu which advises the user of the data upload and asks them to proceed before performing the action
- Change: add confirmation prompt to all vbox scripts 
  - Reason: User may be running directly on hardware not vbox and probably doesnt want to do this.
- Change: Remove sudo invocation from pacman alias 
  - Reason: Not all pacman commands need root to work (ex -Qi), avoids meaningless permission elevation requests.
- Change: Comment out execution of neofetch / all reporting tools
  - Reason: Running whenever a shell opens wastes time and assumes the user keeps neofetch installed
  - This configuration been a default is not config agnostic, skel re-adding it could be frustrating for a user.
  - This kind of thing is something the end-user should elect to set in .bashrc_personal
  - Software list left in about it as a reference / idea for the end-user.

Feel free to make ammendments to this or reject entirely on the grounds of ideological differences. 